### PR TITLE
fix: import-is-undefined using esbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
   "main": "dist/node-paddle-sdk.cjs.js",
   "module": "dist/node-paddle-sdk.es.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "require": "./dist/node-paddle-sdk.cjs.js",
+      "import": "./dist/node-paddle-sdk.es.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "scripts": {
     "lint": "eslint './src/**/*.ts' --quiet --fix",
     "build": "rimraf dist && rollup --config rollup.config.js",


### PR DESCRIPTION
I am seeing this error using this library in a project using esbuild:

```
Import "PaddleSDK" will always be undefined because the file "../../node_modules/.pnpm/@invertase+node-paddle-sdk@0.3.3/node_modules/@invertase/node-paddle-sdk/dist/node-paddle-sdk.cjs.js" has no exports [import-is-undefined]
```

After some research ([here](https://antfu.me/posts/publish-esm-and-cjs#bundling)) i figured out that the adding `exports` in `package.json` solves this issue (I have verified that by applying a patch).